### PR TITLE
Detect whether or not we're running in CI, and if we are, output tests properly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
 machine:
   node:
     version: v6.7.0
+test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "mocha": "3.0.2"
   },
   "scripts": {
-    "test": "npm run lint-allow-warning && mocha --compilers js:babel-register -u tdd test/*",
+    "test": "npm run lint && npm run mocha",
+    "mocha": "mocha --compilers js:babel-register -u tdd $([ -n \"${CI}\" ] && echo --reporter xunit --reporter-options output=$CIRCLE_TEST_REPORTS/junit/mocha.xml) test/*",
     "prepublish": "babel -d lib/ src/",
-    "lint": "eslint --max-warnings 0 -c .eslintrc.json src/ test/",
-    "lint-allow-warning": "eslint -c .eslintrc.json src/ test/"
+    "lint": "eslint --max-warnings 0 -c .eslintrc.json $([ -n \"${CI}\" ] && echo -o $CIRCLE_TEST_REPORTS/junit/eslint.xml -f junit) src/ test/"
   },
   "keywords": [
     "graphql,schema"


### PR DESCRIPTION
This adds some logic to package.json where if we see that we're running in CI, output tests in a format CI actually understands, for a much nicer test display
