### PR TITLE
de-Promise generateSchemaModules

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,17 +11,6 @@ import parseArgs from './parse-args';
 import help from './help';
 import graphqlJsSchema from './index';
 
-tmp.setGracefulCleanup();
-
-const args = parseArgs(process.argv.slice(2));
-
-if (args.showHelp) {
-  console.log(help);
-  process.exit(0);
-}
-
-const schema = JSON.parse(fs.readFileSync(args.schemaFile));
-
 function logFileWrite(filePath) {
   console.log(`wroteFile: ${filePath}`);
 }
@@ -68,7 +57,20 @@ function rollupAndWriteBundle(schemaBundleName, outdir, files) {
   });
 }
 
-graphqlJsSchema(schema, args.schemaBundleName).then((files) => {
+
+function runCli() {
+  tmp.setGracefulCleanup();
+
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.showHelp) {
+    console.log(help);
+    process.exit(0);
+  }
+
+  const schema = JSON.parse(fs.readFileSync(args.schemaFile));
+  const files = graphqlJsSchema(schema, args.schemaBundleName);
+
   if (args.bundleOnly) {
     return rollupAndWriteBundle(args.schemaBundleName, args.outdir, files);
   } else {
@@ -76,7 +78,9 @@ graphqlJsSchema(schema, args.schemaBundleName).then((files) => {
 
     return writeFiles(args.outdir, files);
   }
-}).catch((error) => {
+}
+
+runCli().catch((error) => {
   console.trace(error);
   process.exit(1);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,6 @@ function isObjectOrInterface(type) {
   return isObject(type) || isInterface(type);
 }
 
-function reportError(error) {
-  throw error;
-}
-
 function yieldTypes(schema) {
   return schema.data.__schema.types;
 }
@@ -56,13 +52,17 @@ function injectBundle(bundleName) {
   };
 }
 
+
+function flow(arg, functions) {
+  return functions.reduce(((acc, fn) => fn(acc)), arg);
+}
+
 export default function generateSchemaModules(schema, bundleName) {
-  return Promise
-    .resolve(schema)
-    .then(yieldTypes)
-    .then(filterSupportedTypes)
-    .then(simplifyTypes)
-    .then(mapTypesToFiles)
-    .then(injectBundle(bundleName))
-    .catch(reportError);
+  return flow(schema, [
+    yieldTypes,
+    filterSupportedTypes,
+    simplifyTypes,
+    mapTypesToFiles,
+    injectBundle(bundleName)
+  ]);
 }

--- a/test/generate-schema-modules-test.js
+++ b/test/generate-schema-modules-test.js
@@ -6,11 +6,9 @@ import generateSchemaModules from '../src/index';
 suite('This will validate the output of the `generateSchemaModules` function', () => {
   test('it can convert a schema into a set of files and bundle object', () => {
     const inputSchema = JSON.parse(getFixture('schema.json'));
-
     const expected = JSON.parse(getFixture('simplified-schema-bundle.json'));
+    const modules = generateSchemaModules(inputSchema, 'Schema');
 
-    return generateSchemaModules(inputSchema, 'Schema').then((result) => {
-      assert.deepEqual(result, expected);
-    });
+    assert.deepEqual(modules, expected);
   });
 });


### PR DESCRIPTION
@minasmart and @mikkoh please review.

Modifies the main `generateSchemaModules` function to not use Promises, and refactors dependent code to accommodate this. As discussed last week, Promises aren't necessary with that function because it isn't doing anything asynchronously.
