### PR TITLE
[FEATURE] Handling input object types

### DIFF
--- a/src/simplify-type.js
+++ b/src/simplify-type.js
@@ -16,6 +16,28 @@ function fieldBaseTypes(fields) {
   }, {});
 }
 
+function getInputBaseTypeName(type) {
+  if (type.ofType) {
+    if (type.kind === 'LIST') {
+      return `[${getInputBaseTypeName(type.ofType)}]`;
+    } else if (type.kind === 'NON_NULL') {
+      return `${getInputBaseTypeName(type.ofType)}!`;
+    } else {
+      throw new Error(`Unknown type.kind ${type.kind}`);
+    }
+  } else {
+    return type.name;
+  }
+}
+
+function inputFieldBaseTypes(fields) {
+  return fields.reduce((acc, field) => {
+    acc[field.name] = getInputBaseTypeName(field.type);
+
+    return acc;
+  }, {});
+}
+
 function possibleTypes(interfaceType) {
   return interfaceType.possibleTypes.map((t) => t.name);
 }
@@ -28,6 +50,12 @@ export default function simplifyType(type) {
         kind: type.kind,
         fieldBaseTypes: fieldBaseTypes(type.fields),
         implementsNode: implementsNode(type)
+      });
+    case 'INPUT_OBJECT':
+      return ({
+        name: type.name,
+        kind: type.kind,
+        fieldBaseTypes: inputFieldBaseTypes(type.inputFields)
       });
     case 'INTERFACE':
       return ({

--- a/test-fixtures/schema-input-object-type.json
+++ b/test-fixtures/schema-input-object-type.json
@@ -1,0 +1,85 @@
+{
+  "kind": "INPUT_OBJECT",
+  "name": "InputThing",
+  "description": null,
+  "fields": null,
+  "inputFields": [
+    {
+      "name": "string",
+      "description": null,
+      "type": {
+        "kind": "SCALAR",
+        "name": "String",
+        "ofType": null
+      },
+      "defaultValue": null
+    },
+    {
+      "name": "stringNonNull",
+      "description": null,
+      "type": {
+        "kind": "NON_NULL",
+        "name": "Non-Null",
+        "ofType": {
+          "kind": "SCALAR",
+          "name": "String",
+          "ofType": null
+        }
+      },
+      "defaultValue": null
+    },
+    {
+      "name": "list",
+      "description": null,
+      "type": {
+        "kind": "LIST",
+        "name": "List",
+        "ofType": {
+          "kind": "SCALAR",
+          "name": "String",
+          "ofType": null
+        }
+      },
+      "defaultValue": null
+    },
+    {
+      "name": "listNonNull",
+      "description": null,
+      "type": {
+        "kind": "LIST",
+        "name": "List",
+        "ofType": {
+          "kind": "NON_NULL",
+          "name": "Non-Null",
+          "ofType": {
+            "kind": "SCALAR",
+            "name": "String",
+            "ofType": null
+          }
+        }
+      },
+      "defaultValue": null
+    },
+    {
+      "name": "list2D",
+      "description": null,
+      "type": {
+        "kind": "LIST",
+        "name": "List",
+        "ofType": {
+          "kind": "LIST",
+          "name": "List",
+          "ofType": {
+            "kind": "SCALAR",
+            "name": "String",
+            "ofType": null
+          }
+        }
+      },
+      "defaultValue": null
+    }
+  ],
+  "interfaces": null,
+  "enumValues": null,
+  "possibleTypes": null
+}

--- a/test-fixtures/simplified-input-object-type.json
+++ b/test-fixtures/simplified-input-object-type.json
@@ -1,0 +1,11 @@
+{
+  "name": "InputThing",
+  "kind": "INPUT_OBJECT",
+  "fieldBaseTypes": {
+    "string": "String",
+    "stringNonNull": "String!",
+    "list": "[String]",
+    "listNonNull": "[String!]",
+    "list2D": "[[String]]"
+  }
+}

--- a/test/simplify-type-test.js
+++ b/test/simplify-type-test.js
@@ -11,6 +11,13 @@ suite('This will ensure that we\'re destructuring types from the schema into typ
     assert.deepEqual(simplifyType(schemaObjectType), simplifiedObject);
   });
 
+  test('it simplifies types of kind INPUT_OBJECT', () => {
+    const schemaObjectType = JSON.parse(getFixture('schema-input-object-type.json'));
+    const simplifiedObject = JSON.parse(getFixture('simplified-input-object-type.json'));
+
+    assert.deepEqual(simplifyType(schemaObjectType), simplifiedObject);
+  });
+
   test('it doesn\'t explode when passed a SCALAR type', () => {
     const schemaScalarType = JSON.parse(getFixture('schema-scalar-type.json'));
     const simplifiedScalar = JSON.parse(getFixture('simplified-scalar-type.json'));


### PR DESCRIPTION
This PR implements handling input object types. Since this predominantly would be needed for validation it also handles Non-Null and List types for fields.

Since we want to keep the bundle small in kb the generated code should also be dropped in the same way that the client code will drop non production code.

@minasmart @jamesmacaulay 