### PR TITLE
freeze fieldBaseTypes in output

### DIFF
--- a/src/type-template.js
+++ b/src/type-template.js
@@ -8,6 +8,7 @@ function buildDeclaration(replacements) {
 
   return template(`const TYPE_NAME_IDENTIFIER = ${JSON.stringify(object, null, 2)};`)(replacements);
 }
+const buildFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.fieldBaseTypes);');
 const buildExport = template('export default Object.freeze(TYPE_NAME_IDENTIFIER);', {sourceType: 'module'});
 
 export default function typeTemplate(type) {
@@ -17,10 +18,12 @@ export default function typeTemplate(type) {
   };
 
   const declaration = buildDeclaration(replacements);
+  const freezeStatement = buildFreezeStatement(replacements);
   const moduleExport = buildExport(replacements);
 
   return parse(`
       ${generate(declaration).code}
+      ${generate(freezeStatement).code}
       ${generate(moduleExport).code}
   `, {sourceType: 'module'});
 }

--- a/test-fixtures/simplified-schema-bundle.json
+++ b/test-fixtures/simplified-schema-bundle.json
@@ -1,12 +1,12 @@
 [
   {
     "name": "QueryRoot",
-    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nexport default Object.freeze(QueryRoot);",
+    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nexport default Object.freeze(QueryRoot);",
     "path": "types/query-root.js"
   },
   {
     "name": "Node",
-    "body": "\nconst Node = {\n  \"name\": \"Node\",\n  \"kind\": \"INTERFACE\",\n  \"fieldBaseTypes\": {\n    \"id\": \"ID\"\n  },\n  \"possibleTypes\": [\"Collection\", \"Product\", \"ProductOption\", \"ProductVariant\"]\n};\nexport default Object.freeze(Node);",
+    "body": "\nconst Node = {\n  \"name\": \"Node\",\n  \"kind\": \"INTERFACE\",\n  \"fieldBaseTypes\": {\n    \"id\": \"ID\"\n  },\n  \"possibleTypes\": [\"Collection\", \"Product\", \"ProductOption\", \"ProductVariant\"]\n};\nObject.freeze(Node.fieldBaseTypes);\nexport default Object.freeze(Node);",
     "path": "types/node.js"
   },
   {

--- a/test-fixtures/type-template-output.js
+++ b/test-fixtures/type-template-output.js
@@ -1,16 +1,22 @@
 const Product = {
   "name": "Product",
   "kind": "OBJECT",
-  "scalars": {
-    "title": {
-      "type": "String",
-      "kind": "SCALAR",
-      "isList": true,
-      "args": []
-    }
+  "fieldBaseTypes": {
+    "collections": "CollectionConnection",
+    "createdAt": "DateTime",
+    "handle": "String",
+    "id": "ID",
+    "images": "Image",
+    "options": "ProductOption",
+    "productType": "String",
+    "publishedAt": "DateTime",
+    "tags": "String",
+    "title": "String",
+    "updatedAt": "DateTime",
+    "variants": "ProductVariantConnection",
+    "vendor": "String"
   },
-  "objects": {},
-  "connections": {},
-  "fieldOf": []
+  "implementsNode": true
 };
+Object.freeze(Product.fieldBaseTypes);
 export default Object.freeze(Product);

--- a/test/type-template-test.js
+++ b/test/type-template-test.js
@@ -9,17 +9,22 @@ suite('This will ensure that types can be generated and exported as standalone m
     const type = {
       name: 'Product',
       kind: 'OBJECT',
-      scalars: {
-        title: {
-          type: 'String',
-          kind: 'SCALAR',
-          isList: true,
-          args: []
-        }
+      fieldBaseTypes: {
+        collections: 'CollectionConnection',
+        createdAt: 'DateTime',
+        handle: 'String',
+        id: 'ID',
+        images: 'Image',
+        options: 'ProductOption',
+        productType: 'String',
+        publishedAt: 'DateTime',
+        tags: 'String',
+        title: 'String',
+        updatedAt: 'DateTime',
+        variants: 'ProductVariantConnection',
+        vendor: 'String'
       },
-      objects: {},
-      connections: {},
-      fieldOf: []
+      implementsNode: true
     };
 
     const expected = getFixture('type-template-output.js');


### PR DESCRIPTION
@minasmart please review.

This includes an `Object.freeze` for the nested `fieldBaseTypes` of each type in the bundle output. It's included for scalars too (which don't have the `fieldBaseTypes` property) because I couldn't figure out how to do that conditional logic in the template. It's not really a problem because in those cases it just evaluates to `Object.freeze(undefined)` which is a no-op.