### PR TITLE
Specify root types

### DIFF
--- a/src/bundle-template.js
+++ b/src/bundle-template.js
@@ -11,11 +11,15 @@ function buildImport(replacements) {
 }
 const buildDeclaration = template('const BUNDLE_MODULE_NAME = {types: {}};');
 const buildModuleAssignment = template('BUNDLE_MODULE_NAME.types[TYPE_NAME] = TYPE_NAME_IDENTIFIER;');
+const buildRootLevelAssignment = template('BUNDLE_MODULE_NAME.PROPERTY_NAME = PROPERTY_VALUE;');
 const buildTypesFreeze = template('Object.freeze(BUNDLE_MODULE_NAME.types);');
 const buildExport = template('export default Object.freeze(BUNDLE_MODULE_NAME);', {sourceType: 'module'});
 
-export default function bundleTemplate(types, bundleModuleName) {
+export default function bundleTemplate({queryType, mutationType, subscriptionType}, types, bundleModuleName) {
   const BUNDLE_MODULE_NAME = t.identifier(bundleModuleName);
+  const QUERY_TYPE_NAME = queryType ? t.stringLiteral(queryType) : t.nullLiteral();
+  const MUTATION_TYPE_NAME = mutationType ? t.stringLiteral(mutationType) : t.nullLiteral();
+  const SUBSCRIPTION_TYPE_NAME = subscriptionType ? t.stringLiteral(subscriptionType) : t.nullLiteral();
 
   const typeConfigs = types.map((type) => {
     return {
@@ -29,6 +33,9 @@ export default function bundleTemplate(types, bundleModuleName) {
   const imports = typeConfigs.map((typeConfig) => buildImport(typeConfig));
   const declaration = buildDeclaration({BUNDLE_MODULE_NAME});
   const assignments = typeConfigs.map((typeConfig) => buildModuleAssignment(typeConfig));
+  const queryTypeAssignment = buildRootLevelAssignment({BUNDLE_MODULE_NAME, PROPERTY_NAME: t.identifier('queryType'), PROPERTY_VALUE: QUERY_TYPE_NAME});
+  const mutationTypeAssignment = buildRootLevelAssignment({BUNDLE_MODULE_NAME, PROPERTY_NAME: t.identifier('mutationType'), PROPERTY_VALUE: MUTATION_TYPE_NAME});
+  const subscriptionTypeAssignment = buildRootLevelAssignment({BUNDLE_MODULE_NAME, PROPERTY_NAME: t.identifier('subscriptionType'), PROPERTY_VALUE: SUBSCRIPTION_TYPE_NAME});
   const typesFreeze = buildTypesFreeze({BUNDLE_MODULE_NAME});
   const moduleExport = buildExport({BUNDLE_MODULE_NAME});
 
@@ -36,6 +43,9 @@ export default function bundleTemplate(types, bundleModuleName) {
     ${imports.map((ast) => generate(ast).code).join('\n')}
     ${generate(declaration).code}
     ${assignments.map((ast) => generate(ast).code).join('\n')}
+    ${generate(queryTypeAssignment).code}
+    ${generate(mutationTypeAssignment).code}
+    ${generate(subscriptionTypeAssignment).code}
     ${generate(typesFreeze).code}
     ${generate(moduleExport).code}
   `, {sourceType: 'module'});

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,9 @@ function mapTypesToFiles(simplifiedTypes) {
   });
 }
 
-function injectBundle(bundleName) {
+function injectBundle({queryType, mutationType, subscriptionType}, bundleName) {
   return function(typeFileMaps) {
-    const bundleAst = bundleTemplate(typeFileMaps, bundleName.replace(' ', ''));
+    const bundleAst = bundleTemplate({queryType, mutationType, subscriptionType}, typeFileMaps, bundleName.replace(' ', ''));
     const bundle = generate(bundleAst).code;
 
     typeFileMaps.push({
@@ -51,6 +51,6 @@ export default function generateSchemaModules(schema, bundleName) {
     yieldTypes,
     simplifyTypes,
     mapTypesToFiles,
-    injectBundle(bundleName)
+    injectBundle(schema, bundleName)
   ]);
 }

--- a/test-fixtures/multi-resource-bundle.js
+++ b/test-fixtures/multi-resource-bundle.js
@@ -7,5 +7,8 @@ const Types = {
 Types.types["Product"] = Product;
 Types.types["Shop"] = Shop;
 Types.types["Collection"] = Collection;
+Types.queryType = "Shop";
+Types.mutationType = null;
+Types.subscriptionType = null;
 Object.freeze(Types.types);
 export default Object.freeze(Types);

--- a/test-fixtures/simplified-schema-bundle.json
+++ b/test-fixtures/simplified-schema-bundle.json
@@ -10,7 +10,7 @@
     "path": "types/node.js"
   },
   {
-    "body": "\nimport QueryRoot from \"./types/query-root\";\nimport Node from \"./types/node\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.types[\"Node\"] = Node;\nObject.freeze(Schema.types);\nexport default Object.freeze(Schema);",
+    "body": "\nimport QueryRoot from \"./types/query-root\";\nimport Node from \"./types/node\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.types[\"Node\"] = Node;\nSchema.queryType = null;\nSchema.mutationType = null;\nSchema.subscriptionType = null;\nObject.freeze(Schema.types);\nexport default Object.freeze(Schema);",
     "path": "schema.js"
   }
 ]

--- a/test-fixtures/single-resource-bundle.js
+++ b/test-fixtures/single-resource-bundle.js
@@ -3,5 +3,8 @@ const Schema = {
   types: {}
 };
 Schema.types["SomeType"] = SomeType;
+Schema.queryType = "SomeType";
+Schema.mutationType = null;
+Schema.subscriptionType = null;
 Object.freeze(Schema.types);
 export default Object.freeze(Schema);

--- a/test-fixtures/zero-resource-bundle.js
+++ b/test-fixtures/zero-resource-bundle.js
@@ -2,5 +2,8 @@ const Bundle = {
   types: {}
 };
 
+Bundle.queryType = null;
+Bundle.mutationType = null;
+Bundle.subscriptionType = null;
 Object.freeze(Bundle.types);
 export default Object.freeze(Bundle);

--- a/test/bundle-template-test.js
+++ b/test/bundle-template-test.js
@@ -7,10 +7,9 @@ import bundleTemplate from '../src/bundle-template';
 suite('This will ensure that bundles can be generated', () => {
   test('it can handle single types', () => {
     const types = [{name: 'SomeType', path: 'path/to/some/type.js'}];
-
+    const rootTypeNames = {queryType: 'SomeType', mutationType: null, subscriptionType: null};
     const expected = getFixture('single-resource-bundle.js');
-
-    const output = bundleTemplate(types, 'Schema');
+    const output = bundleTemplate(rootTypeNames, types, 'Schema');
 
     assert.equal(generate(output).code.trim(), expected.trim());
   });
@@ -23,20 +22,18 @@ suite('This will ensure that bundles can be generated', () => {
     }, {
       name: 'Collection', path: 'types/collection.js'
     }];
-
+    const rootTypeNames = {queryType: 'Shop', mutationType: null, subscriptionType: null};
     const expected = getFixture('multi-resource-bundle.js');
-
-    const output = bundleTemplate(types, 'Types');
+    const output = bundleTemplate(rootTypeNames, types, 'Types');
 
     assert.equal(generate(output).code.trim(), expected.trim());
   });
 
   test('it doesn\'t explode when passed no types', () => {
     const types = [];
-
+    const rootTypeNames = {queryType: null, mutationType: null, subscriptionType: null};
     const expected = getFixture('zero-resource-bundle.js');
-
-    const output = bundleTemplate(types, 'Bundle');
+    const output = bundleTemplate(rootTypeNames, types, 'Bundle');
 
     assert.equal(generate(output).code.trim(), expected.trim());
   });


### PR DESCRIPTION
@minasmart please review.

This alters the structure of the type bundle to include `queryType`, `mutationType`, and `subscriptionType` in the output. This is necessary because not all valid schemas use the conventional `QueryRoot` etc.

In order to accommodate the added fields, the type dictionary itself is nested under a `types` property.