### PR TITLE
fix extracting root type names from actual schemas

### DIFF
--- a/src/bundle-template.js
+++ b/src/bundle-template.js
@@ -15,11 +15,11 @@ const buildRootLevelAssignment = template('BUNDLE_MODULE_NAME.PROPERTY_NAME = PR
 const buildTypesFreeze = template('Object.freeze(BUNDLE_MODULE_NAME.types);');
 const buildExport = template('export default Object.freeze(BUNDLE_MODULE_NAME);', {sourceType: 'module'});
 
-export default function bundleTemplate({queryType, mutationType, subscriptionType}, types, bundleModuleName) {
+export default function bundleTemplate({queryTypeName, mutationTypeName, subscriptionTypeName}, types, bundleModuleName) {
   const BUNDLE_MODULE_NAME = t.identifier(bundleModuleName);
-  const QUERY_TYPE_NAME = queryType ? t.stringLiteral(queryType) : t.nullLiteral();
-  const MUTATION_TYPE_NAME = mutationType ? t.stringLiteral(mutationType) : t.nullLiteral();
-  const SUBSCRIPTION_TYPE_NAME = subscriptionType ? t.stringLiteral(subscriptionType) : t.nullLiteral();
+  const QUERY_TYPE_NAME = queryTypeName ? t.stringLiteral(queryTypeName) : t.nullLiteral();
+  const MUTATION_TYPE_NAME = mutationTypeName ? t.stringLiteral(mutationTypeName) : t.nullLiteral();
+  const SUBSCRIPTION_TYPE_NAME = subscriptionTypeName ? t.stringLiteral(subscriptionTypeName) : t.nullLiteral();
 
   const typeConfigs = types.map((type) => {
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -27,9 +27,9 @@ function mapTypesToFiles(simplifiedTypes) {
   });
 }
 
-function injectBundle({queryType, mutationType, subscriptionType}, bundleName) {
+function injectBundle(rootTypeNames, bundleName) {
   return function(typeFileMaps) {
-    const bundleAst = bundleTemplate({queryType, mutationType, subscriptionType}, typeFileMaps, bundleName.replace(' ', ''));
+    const bundleAst = bundleTemplate(rootTypeNames, typeFileMaps, bundleName.replace(' ', ''));
     const bundle = generate(bundleAst).code;
 
     typeFileMaps.push({
@@ -39,6 +39,14 @@ function injectBundle({queryType, mutationType, subscriptionType}, bundleName) {
 
     return typeFileMaps;
   };
+}
+
+function extractRootTypeNames({queryType, mutationType, subscriptionType}) {
+  return ({
+    queryTypeName: (queryType ? queryType.name : null),
+    mutationTypeName: (mutationType ? mutationType.name : null),
+    subscriptionTypeName: (subscriptionType ? subscriptionType.name : null)
+  });
 }
 
 
@@ -51,6 +59,6 @@ export default function generateSchemaModules(schema, bundleName) {
     yieldTypes,
     simplifyTypes,
     mapTypesToFiles,
-    injectBundle(schema, bundleName)
+    injectBundle(extractRootTypeNames(schema), bundleName)
   ]);
 }

--- a/test/bundle-template-test.js
+++ b/test/bundle-template-test.js
@@ -7,7 +7,7 @@ import bundleTemplate from '../src/bundle-template';
 suite('This will ensure that bundles can be generated', () => {
   test('it can handle single types', () => {
     const types = [{name: 'SomeType', path: 'path/to/some/type.js'}];
-    const rootTypeNames = {queryType: 'SomeType', mutationType: null, subscriptionType: null};
+    const rootTypeNames = {queryTypeName: 'SomeType', mutationTypeName: null, subscriptionTypeName: null};
     const expected = getFixture('single-resource-bundle.js');
     const output = bundleTemplate(rootTypeNames, types, 'Schema');
 
@@ -22,7 +22,7 @@ suite('This will ensure that bundles can be generated', () => {
     }, {
       name: 'Collection', path: 'types/collection.js'
     }];
-    const rootTypeNames = {queryType: 'Shop', mutationType: null, subscriptionType: null};
+    const rootTypeNames = {queryTypeName: 'Shop', mutationTypeName: null, subscriptionTypeName: null};
     const expected = getFixture('multi-resource-bundle.js');
     const output = bundleTemplate(rootTypeNames, types, 'Types');
 
@@ -31,7 +31,7 @@ suite('This will ensure that bundles can be generated', () => {
 
   test('it doesn\'t explode when passed no types', () => {
     const types = [];
-    const rootTypeNames = {queryType: null, mutationType: null, subscriptionType: null};
+    const rootTypeNames = {queryTypeName: null, mutationTypeName: null, subscriptionTypeName: null};
     const expected = getFixture('zero-resource-bundle.js');
     const output = bundleTemplate(rootTypeNames, types, 'Bundle');
 


### PR DESCRIPTION
@minasmart please review.

I forgot the actual shape of introspection responses – this fixes things to correctly extract names from type objects.