### PR TITLE
freeze possibleTypes array for interfaces

### DIFF
--- a/src/type-template.js
+++ b/src/type-template.js
@@ -8,7 +8,8 @@ function buildDeclaration(replacements) {
 
   return template(`const TYPE_NAME_IDENTIFIER = ${JSON.stringify(object, null, 2)};`)(replacements);
 }
-const buildFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.fieldBaseTypes);');
+const buildFieldBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.fieldBaseTypes);');
+const buildPossibleTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.possibleTypes);');
 const buildExport = template('export default Object.freeze(TYPE_NAME_IDENTIFIER);', {sourceType: 'module'});
 
 export default function typeTemplate(type) {
@@ -18,12 +19,14 @@ export default function typeTemplate(type) {
   };
 
   const declaration = buildDeclaration(replacements);
-  const freezeStatement = buildFreezeStatement(replacements);
+  const fieldBaseTypesFreezeStatement = buildFieldBaseTypesFreezeStatement(replacements);
+  const possibleTypesFreezeStatement = buildPossibleTypesFreezeStatement(replacements);
   const moduleExport = buildExport(replacements);
 
   return parse(`
       ${generate(declaration).code}
-      ${generate(freezeStatement).code}
+      ${generate(fieldBaseTypesFreezeStatement).code}
+      ${generate(possibleTypesFreezeStatement).code}
       ${generate(moduleExport).code}
   `, {sourceType: 'module'});
 }

--- a/test-fixtures/simplified-schema-bundle.json
+++ b/test-fixtures/simplified-schema-bundle.json
@@ -1,12 +1,12 @@
 [
   {
     "name": "QueryRoot",
-    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nexport default Object.freeze(QueryRoot);",
+    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nObject.freeze(QueryRoot.possibleTypes);\nexport default Object.freeze(QueryRoot);",
     "path": "types/query-root.js"
   },
   {
     "name": "Node",
-    "body": "\nconst Node = {\n  \"name\": \"Node\",\n  \"kind\": \"INTERFACE\",\n  \"fieldBaseTypes\": {\n    \"id\": \"ID\"\n  },\n  \"possibleTypes\": [\"Collection\", \"Product\", \"ProductOption\", \"ProductVariant\"]\n};\nObject.freeze(Node.fieldBaseTypes);\nexport default Object.freeze(Node);",
+    "body": "\nconst Node = {\n  \"name\": \"Node\",\n  \"kind\": \"INTERFACE\",\n  \"fieldBaseTypes\": {\n    \"id\": \"ID\"\n  },\n  \"possibleTypes\": [\"Collection\", \"Product\", \"ProductOption\", \"ProductVariant\"]\n};\nObject.freeze(Node.fieldBaseTypes);\nObject.freeze(Node.possibleTypes);\nexport default Object.freeze(Node);",
     "path": "types/node.js"
   },
   {

--- a/test-fixtures/type-template-output.js
+++ b/test-fixtures/type-template-output.js
@@ -19,4 +19,5 @@ const Product = {
   "implementsNode": true
 };
 Object.freeze(Product.fieldBaseTypes);
+Object.freeze(Product.possibleTypes);
 export default Object.freeze(Product);


### PR DESCRIPTION
@minasmart please review.

This does an Object.freeze on each type's `possibleTypes` property. This property only exists on interfaces, so when the template generation gets refactored it should be made smarter about only freezing the property when it's present.