### PR TITLE
Add mutation schema representations

### DIFF
--- a/src/simplify-type.js
+++ b/src/simplify-type.js
@@ -8,6 +8,14 @@ function getBaseTypeName(type) {
   }
 }
 
+function getBaseTypeKind(type) {
+  if (type.ofType) {
+    return getBaseTypeKind(type.ofType);
+  } else {
+    return type.kind;
+  }
+}
+
 function fieldBaseTypes(fields) {
   return fields.reduce((acc, field) => {
     acc[field.name] = getBaseTypeName(field.type);
@@ -16,30 +24,52 @@ function fieldBaseTypes(fields) {
   }, {});
 }
 
+function relayInputObjectBaseTypes(fields) {
+  return fields.reduce((acc, field) => {
+    const inputArg = field.args.find(isInputArg);
+
+    if (inputArg) {
+      acc[field.name] = getBaseTypeName(inputArg.type);
+    }
+
+    return acc;
+  }, {});
+}
+
+function isInputArg(arg) {
+  return arg.name === 'input' && getBaseTypeKind(arg.type) === 'INPUT_OBJECT';
+}
+
 function possibleTypes(interfaceType) {
   return interfaceType.possibleTypes.map((t) => t.name);
 }
 
 export default function simplifyType(type) {
+  const simplifiedType = {
+    name: type.name,
+    kind: type.kind
+  };
+
   switch (type.kind) {
     case 'OBJECT':
-      return ({
-        name: type.name,
-        kind: type.kind,
-        fieldBaseTypes: fieldBaseTypes(type.fields),
-        implementsNode: implementsNode(type)
-      });
+      simplifiedType.fieldBaseTypes = fieldBaseTypes(type.fields);
+      simplifiedType.implementsNode = implementsNode(type);
+
+      if (type.name === 'Mutation') {
+        simplifiedType.relayInputObjectBaseTypes = relayInputObjectBaseTypes(type.fields);
+      }
+
+      return simplifiedType;
     case 'INTERFACE':
-      return ({
-        name: type.name,
-        kind: type.kind,
-        fieldBaseTypes: fieldBaseTypes(type.fields),
-        possibleTypes: possibleTypes(type)
-      });
+      simplifiedType.fieldBaseTypes = fieldBaseTypes(type.fields);
+      simplifiedType.possibleTypes = possibleTypes(type);
+
+      return simplifiedType;
+    case 'INPUT_OBJECT':
+      simplifiedType.inputFieldBaseTypes = fieldBaseTypes(type.inputFields);
+
+      return simplifiedType;
     default:
-      return ({
-        name: type.name,
-        kind: type.kind
-      });
+      return simplifiedType;
   }
 }

--- a/src/type-template.js
+++ b/src/type-template.js
@@ -9,6 +9,8 @@ function buildDeclaration(replacements) {
   return template(`const TYPE_NAME_IDENTIFIER = ${JSON.stringify(object, null, 2)};`)(replacements);
 }
 const buildFieldBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.fieldBaseTypes);');
+const buildRelayInputObjectBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.relayInputObjectBaseTypes);');
+const buildInputFieldBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.inputFieldBaseTypes);');
 const buildPossibleTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.possibleTypes);');
 const buildExport = template('export default Object.freeze(TYPE_NAME_IDENTIFIER);', {sourceType: 'module'});
 
@@ -20,13 +22,44 @@ export default function typeTemplate(type) {
 
   const declaration = buildDeclaration(replacements);
   const fieldBaseTypesFreezeStatement = buildFieldBaseTypesFreezeStatement(replacements);
+  const relayInputObjectBaseTypesFreezeStatement = buildRelayInputObjectBaseTypesFreezeStatement(replacements);
+  const inputFieldBaseTypesFreezeStatement = buildInputFieldBaseTypesFreezeStatement(replacements);
   const possibleTypesFreezeStatement = buildPossibleTypesFreezeStatement(replacements);
   const moduleExport = buildExport(replacements);
 
-  return parse(`
-      ${generate(declaration).code}
-      ${generate(fieldBaseTypesFreezeStatement).code}
-      ${generate(possibleTypesFreezeStatement).code}
-      ${generate(moduleExport).code}
-  `, {sourceType: 'module'});
+  switch (type.kind) {
+    case 'OBJECT':
+      if (type.name === 'Mutation') {
+        return parse(`
+            ${generate(declaration).code}
+            ${generate(fieldBaseTypesFreezeStatement).code}
+            ${generate(relayInputObjectBaseTypesFreezeStatement).code}
+            ${generate(moduleExport).code}
+        `, {sourceType: 'module'});
+      } else {
+        return parse(`
+            ${generate(declaration).code}
+            ${generate(fieldBaseTypesFreezeStatement).code}
+            ${generate(moduleExport).code}
+        `, {sourceType: 'module'});
+      }
+    case 'INTERFACE':
+      return parse(`
+          ${generate(declaration).code}
+          ${generate(fieldBaseTypesFreezeStatement).code}
+          ${generate(possibleTypesFreezeStatement).code}
+          ${generate(moduleExport).code}
+      `, {sourceType: 'module'});
+    case 'INPUT_OBJECT':
+      return parse(`
+          ${generate(declaration).code}
+          ${generate(inputFieldBaseTypesFreezeStatement).code}
+          ${generate(moduleExport).code}
+      `, {sourceType: 'module'});
+    default:
+      return parse(`
+          ${generate(declaration).code}
+          ${generate(moduleExport).code}
+      `, {sourceType: 'module'});
+  }
 }

--- a/test-fixtures/input-object-type-template-output.js
+++ b/test-fixtures/input-object-type-template-output.js
@@ -1,0 +1,11 @@
+const ApiCustomerAccessTokenCreateInput = {
+  "name": "ApiCustomerAccessTokenCreateInput",
+  "kind": "INPUT_OBJECT",
+  "inputFieldBaseTypes": {
+    "clientMutationId": "String",
+    "email": "String",
+    "password": "String"
+  }
+};
+Object.freeze(ApiCustomerAccessTokenCreateInput.inputFieldBaseTypes);
+export default Object.freeze(ApiCustomerAccessTokenCreateInput);

--- a/test-fixtures/interface-type-template-output.js
+++ b/test-fixtures/interface-type-template-output.js
@@ -1,0 +1,11 @@
+const Node = {
+  "name": "Node",
+  "kind": "INTERFACE",
+  "fieldBaseTypes": {
+    "id": "ID"
+  },
+  "possibleTypes": ["ApiCustomerAccessToken", "Collection", "CreditCardPaymentRequest", "Order", "Product", "ProductOption", "ProductVariant", "PurchaseSession", "ShippingRatesRequest", "ShopPolicy"]
+};
+Object.freeze(Node.fieldBaseTypes);
+Object.freeze(Node.possibleTypes);
+export default Object.freeze(Node);

--- a/test-fixtures/mutation-object-type-template-output.js
+++ b/test-fixtures/mutation-object-type-template-output.js
@@ -1,0 +1,18 @@
+const Mutation = {
+  "name": "Mutation",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "apiCustomerAccessTokenCreate": "ApiCustomerAccessTokenCreatePayload",
+    "apiCustomerAccessTokenDelete": "ApiCustomerAccessTokenDeletePayload",
+    "apiCustomerAccessTokenRenew": "ApiCustomerAccessTokenRenewPayload"
+  },
+  "implementsNode": false,
+  "relayInputObjectBaseTypes": {
+    "apiCustomerAccessTokenCreate": "ApiCustomerAccessTokenCreateInput",
+    "apiCustomerAccessTokenDelete": "ApiCustomerAccessTokenDeleteInput",
+    "apiCustomerAccessTokenRenew": "ApiCustomerAccessTokenRenewInput"
+  }
+};
+Object.freeze(Mutation.fieldBaseTypes);
+Object.freeze(Mutation.relayInputObjectBaseTypes);
+export default Object.freeze(Mutation);

--- a/test-fixtures/object-type-template-output.js
+++ b/test-fixtures/object-type-template-output.js
@@ -19,5 +19,4 @@ const Product = {
   "implementsNode": true
 };
 Object.freeze(Product.fieldBaseTypes);
-Object.freeze(Product.possibleTypes);
 export default Object.freeze(Product);

--- a/test-fixtures/schema-input-object-type.json
+++ b/test-fixtures/schema-input-object-type.json
@@ -1,0 +1,49 @@
+{
+  "kind": "INPUT_OBJECT",
+  "name": "ApiCustomerAccessTokenCreateInput",
+  "description": null,
+  "fields": null,
+  "inputFields": [
+    {
+      "name": "clientMutationId",
+      "description": null,
+      "type": {
+        "kind": "SCALAR",
+        "name": "String",
+        "ofType": null
+      },
+      "defaultValue": null
+    },
+    {
+      "name": "email",
+      "description": null,
+      "type": {
+        "kind": "NON_NULL",
+        "name": null,
+        "ofType": {
+          "kind": "SCALAR",
+          "name": "String",
+          "ofType": null
+        }
+      },
+      "defaultValue": null
+    },
+    {
+      "name": "password",
+      "description": null,
+      "type": {
+        "kind": "NON_NULL",
+        "name": null,
+        "ofType": {
+          "kind": "SCALAR",
+          "name": "String",
+          "ofType": null
+        }
+      },
+      "defaultValue": null
+    }
+  ],
+  "interfaces": null,
+  "enumValues": null,
+  "possibleTypes": null
+}

--- a/test-fixtures/schema-mutation-object-type.json
+++ b/test-fixtures/schema-mutation-object-type.json
@@ -1,0 +1,88 @@
+{
+  "kind": "OBJECT",
+  "name": "Mutation",
+  "description": null,
+  "fields": [
+    {
+      "name": "apiCustomerAccessTokenCreate",
+      "description": null,
+      "args": [
+        {
+          "name": "input",
+          "description": null,
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "INPUT_OBJECT",
+              "name": "ApiCustomerAccessTokenCreateInput",
+              "ofType": null
+            }
+          },
+          "defaultValue": null
+        }
+      ],
+      "type": {
+        "kind": "OBJECT",
+        "name": "ApiCustomerAccessTokenCreatePayload",
+        "ofType": null
+      },
+      "isDeprecated": false,
+      "deprecationReason": null
+    },
+    {
+      "name": "apiCustomerAccessTokenDelete",
+      "description": null,
+      "args": [
+        {
+          "name": "input",
+          "description": null,
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "INPUT_OBJECT",
+              "name": "ApiCustomerAccessTokenDeleteInput",
+              "ofType": null
+            }
+          },
+          "defaultValue": null
+        }
+      ],
+      "type": {
+        "kind": "OBJECT",
+        "name": "ApiCustomerAccessTokenDeletePayload",
+        "ofType": null
+      },
+      "isDeprecated": false,
+      "deprecationReason": null
+    },
+    {
+      "name": "apiCustomerAccessTokenRenew",
+      "description": null,
+      "args": [
+        {
+          "name": "input",
+          "description": null,
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "INPUT_OBJECT",
+              "name": "ApiCustomerAccessTokenRenewInput",
+              "ofType": null
+            }
+          },
+          "defaultValue": null
+        }
+      ],
+      "type": {
+        "kind": "OBJECT",
+        "name": "ApiCustomerAccessTokenRenewPayload",
+        "ofType": null
+      },
+      "isDeprecated": false,
+      "deprecationReason": null
+    }
+  ]
+}

--- a/test-fixtures/schema.json
+++ b/test-fixtures/schema.json
@@ -4,7 +4,9 @@
       "queryType": {
         "name": "QueryRoot"
       },
-      "mutationType": null,
+      "mutationType": {
+        "name": "Mutation"
+      },
       "subscriptionType": null,
       "types": [
         {
@@ -163,6 +165,93 @@
               "kind": "OBJECT",
               "name": "ProductVariant",
               "ofType": null
+            }
+          ]
+        }, {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": null,
+          "fields": [
+            {
+              "name": "apiCustomerAccessTokenCreate",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ApiCustomerAccessTokenCreateInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ApiCustomerAccessTokenCreatePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "apiCustomerAccessTokenDelete",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ApiCustomerAccessTokenDeleteInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ApiCustomerAccessTokenDeletePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "apiCustomerAccessTokenRenew",
+              "description": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ApiCustomerAccessTokenRenewInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ApiCustomerAccessTokenRenewPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         }

--- a/test-fixtures/simplified-input-object-type.json
+++ b/test-fixtures/simplified-input-object-type.json
@@ -1,0 +1,9 @@
+{
+  "name": "ApiCustomerAccessTokenCreateInput",
+  "kind": "INPUT_OBJECT",
+  "inputFieldBaseTypes": {
+    "clientMutationId": "String",
+    "email": "String",
+    "password": "String"
+  }
+}

--- a/test-fixtures/simplified-mutation-object-type.json
+++ b/test-fixtures/simplified-mutation-object-type.json
@@ -1,0 +1,15 @@
+{
+  "name": "Mutation",
+  "kind": "OBJECT",
+  "fieldBaseTypes": {
+    "apiCustomerAccessTokenCreate": "ApiCustomerAccessTokenCreatePayload",
+    "apiCustomerAccessTokenDelete": "ApiCustomerAccessTokenDeletePayload",
+    "apiCustomerAccessTokenRenew": "ApiCustomerAccessTokenRenewPayload"
+  },
+  "relayInputObjectBaseTypes": {
+    "apiCustomerAccessTokenCreate": "ApiCustomerAccessTokenCreateInput",
+    "apiCustomerAccessTokenDelete": "ApiCustomerAccessTokenDeleteInput",
+    "apiCustomerAccessTokenRenew": "ApiCustomerAccessTokenRenewInput"
+  },
+  "implementsNode": false
+}

--- a/test-fixtures/simplified-schema-bundle.json
+++ b/test-fixtures/simplified-schema-bundle.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "QueryRoot",
-    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nObject.freeze(QueryRoot.possibleTypes);\nexport default Object.freeze(QueryRoot);",
+    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nexport default Object.freeze(QueryRoot);",
     "path": "types/query-root.js"
   },
   {
@@ -10,7 +10,12 @@
     "path": "types/node.js"
   },
   {
-    "body": "\nimport QueryRoot from \"./types/query-root\";\nimport Node from \"./types/node\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.types[\"Node\"] = Node;\nSchema.queryType = \"QueryRoot\";\nSchema.mutationType = null;\nSchema.subscriptionType = null;\nObject.freeze(Schema.types);\nexport default Object.freeze(Schema);",
+    "name": "Mutation",
+    "body": "\nconst Mutation = {\n  \"name\": \"Mutation\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"apiCustomerAccessTokenCreate\": \"ApiCustomerAccessTokenCreatePayload\",\n    \"apiCustomerAccessTokenDelete\": \"ApiCustomerAccessTokenDeletePayload\",\n    \"apiCustomerAccessTokenRenew\": \"ApiCustomerAccessTokenRenewPayload\"\n  },\n  \"implementsNode\": false,\n  \"relayInputObjectBaseTypes\": {\n    \"apiCustomerAccessTokenCreate\": \"ApiCustomerAccessTokenCreateInput\",\n    \"apiCustomerAccessTokenDelete\": \"ApiCustomerAccessTokenDeleteInput\",\n    \"apiCustomerAccessTokenRenew\": \"ApiCustomerAccessTokenRenewInput\"\n  }\n};\nObject.freeze(Mutation.fieldBaseTypes);\nObject.freeze(Mutation.relayInputObjectBaseTypes);\nexport default Object.freeze(Mutation);",
+    "path": "types/mutation.js"
+  },
+  {
+    "body": "\nimport QueryRoot from \"./types/query-root\";\nimport Node from \"./types/node\";\nimport Mutation from \"./types/mutation\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.types[\"Node\"] = Node;\nSchema.types[\"Mutation\"] = Mutation;\nSchema.queryType = \"QueryRoot\";\nSchema.mutationType = \"Mutation\";\nSchema.subscriptionType = null;\nObject.freeze(Schema.types);\nexport default Object.freeze(Schema);",
     "path": "schema.js"
   }
 ]

--- a/test/simplify-type-test.js
+++ b/test/simplify-type-test.js
@@ -11,6 +11,20 @@ suite('This will ensure that we\'re destructuring types from the schema into typ
     assert.deepEqual(simplifyType(schemaObjectType), simplifiedObject);
   });
 
+  test('it generates inputFieldBaseTypes for kind OBJECT with name Mutation', () => {
+    const schemaObjectType = JSON.parse(getFixture('schema-mutation-object-type.json'));
+    const simplifiedObject = JSON.parse(getFixture('simplified-mutation-object-type.json'));
+
+    assert.deepEqual(simplifyType(schemaObjectType), simplifiedObject);
+  });
+
+  test('it simplifies types of kind INPUT_OBJECT', () => {
+    const schemaObjectType = JSON.parse(getFixture('schema-input-object-type.json'));
+    const simplifiedObject = JSON.parse(getFixture('simplified-input-object-type.json'));
+
+    assert.deepEqual(simplifyType(schemaObjectType), simplifiedObject);
+  });
+
   test('it doesn\'t explode when passed a SCALAR type', () => {
     const schemaScalarType = JSON.parse(getFixture('schema-scalar-type.json'));
     const simplifiedScalar = JSON.parse(getFixture('simplified-scalar-type.json'));

--- a/test/type-template-test.js
+++ b/test/type-template-test.js
@@ -5,7 +5,7 @@ import getFixture from './get-fixture';
 import typeTemplate from '../src/type-template';
 
 suite('This will ensure that types can be generated and exported as standalone modules', () => {
-  test('it exports types', () => {
+  test('it exports OBJECT types', () => {
     const type = {
       name: 'Product',
       kind: 'OBJECT',
@@ -27,7 +27,66 @@ suite('This will ensure that types can be generated and exported as standalone m
       implementsNode: true
     };
 
-    const expected = getFixture('type-template-output.js');
+    const expected = getFixture('object-type-template-output.js');
+
+    const output = typeTemplate(type);
+
+    assert.equal(generate(output).code.trim(), expected.trim());
+  });
+
+  test('it exports OBJECT types of name Mutation', () => {
+    const type = {
+      name: 'Mutation',
+      kind: 'OBJECT',
+      fieldBaseTypes: {
+        apiCustomerAccessTokenCreate: 'ApiCustomerAccessTokenCreatePayload',
+        apiCustomerAccessTokenDelete: 'ApiCustomerAccessTokenDeletePayload',
+        apiCustomerAccessTokenRenew: 'ApiCustomerAccessTokenRenewPayload'
+      },
+      implementsNode: false,
+      relayInputObjectBaseTypes: {
+        apiCustomerAccessTokenCreate: 'ApiCustomerAccessTokenCreateInput',
+        apiCustomerAccessTokenDelete: 'ApiCustomerAccessTokenDeleteInput',
+        apiCustomerAccessTokenRenew: 'ApiCustomerAccessTokenRenewInput'
+      }
+    };
+
+    const expected = getFixture('mutation-object-type-template-output.js');
+
+    const output = typeTemplate(type);
+
+    assert.equal(generate(output).code.trim(), expected.trim());
+  });
+
+  test('it exports INPUT_OBJECT types', () => {
+    const type = {
+      name: 'ApiCustomerAccessTokenCreateInput',
+      kind: 'INPUT_OBJECT',
+      inputFieldBaseTypes: {
+        clientMutationId: 'String',
+        email: 'String',
+        password: 'String'
+      }
+    };
+
+    const expected = getFixture('input-object-type-template-output.js');
+
+    const output = typeTemplate(type);
+
+    assert.equal(generate(output).code.trim(), expected.trim());
+  });
+
+  test('it exports INTERFACE types', () => {
+    const type = {
+      name: 'Node',
+      kind: 'INTERFACE',
+      fieldBaseTypes: {
+        id: 'ID'
+      },
+      possibleTypes: ['ApiCustomerAccessToken', 'Collection', 'CreditCardPaymentRequest', 'Order', 'Product', 'ProductOption', 'ProductVariant', 'PurchaseSession', 'ShippingRatesRequest', 'ShopPolicy']
+    };
+
+    const expected = getFixture('interface-type-template-output.js');
 
     const output = typeTemplate(type);
 


### PR DESCRIPTION
Currently, this module generates Mutation types but doesn't handle the Input Types. The Mutation object should have a mapping to the input_object types and the input_object types should have input_fields listed.

This PR: 
- adds inputFieldBaseType on kind OBJECT with name Mutation
- simplifies type for INPUT_OBJECTS

GitHub Issue: https://github.com/Shopify/storefront-api-team-projects/issues/41