### PR TITLE
Optimize Object Freezing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,64 +3,13 @@
 import fs from 'fs';
 import path from 'path';
 import mkdirp from 'mkdirp';
-import tmp from 'tmp';
-import {rollup} from 'rollup';
-import dasherize from 'lodash.kebabcase';
 
 import parseArgs from './parse-args';
 import help from './help';
+import {writeFiles, rollupAndWriteBundle} from './writers';
 import generateSchemaModules from './index';
 
-function logFileWrite(filePath) {
-  console.log(`wroteFile: ${filePath}`);
-}
-
-function writeFiles(outdir, files, quiet = false) {
-  return Promise.all(files.map((file) => {
-    return new Promise((resolve, reject) => {
-      fs.writeFile(path.join(outdir, file.path), file.body, (err) => {
-        if (err) {
-          reject(err);
-
-          return;
-        }
-
-        if (!quiet) {
-          logFileWrite(path.join(outdir, file.path));
-        }
-        resolve();
-      });
-    });
-  }));
-}
-
-function rollupAndWriteBundle(schemaBundleName, outdir, files) {
-  const tmpDir = tmp.dirSync();
-
-  mkdirp.sync(path.join(tmpDir.name, 'types'));
-
-  const entryFilename = `${dasherize(schemaBundleName)}.js`;
-  const entryFilePath = path.join(tmpDir.name, entryFilename);
-  const bundleFilePath = path.join(outdir, entryFilename);
-
-  return writeFiles(tmpDir.name, files, true).then(() => {
-    return rollup({
-      entry: entryFilePath
-    });
-  }).then((bundle) => {
-    return bundle.write({
-      format: 'es',
-      dest: bundleFilePath
-    });
-  }).then(() => {
-    logFileWrite(bundleFilePath);
-  });
-}
-
-
 function runCli() {
-  tmp.setGracefulCleanup();
-
   const args = parseArgs(process.argv.slice(2));
 
   if (args.showHelp) {

--- a/src/type-template.js
+++ b/src/type-template.js
@@ -8,11 +8,7 @@ function buildDeclaration(replacements) {
 
   return template(`const TYPE_NAME_IDENTIFIER = ${JSON.stringify(object, null, 2)};`)(replacements);
 }
-const buildFieldBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.fieldBaseTypes);');
-const buildRelayInputObjectBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.relayInputObjectBaseTypes);');
-const buildInputFieldBaseTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.inputFieldBaseTypes);');
-const buildPossibleTypesFreezeStatement = template('Object.freeze(TYPE_NAME_IDENTIFIER.possibleTypes);');
-const buildExport = template('export default Object.freeze(TYPE_NAME_IDENTIFIER);', {sourceType: 'module'});
+const buildExport = template('export default TYPE_NAME_IDENTIFIER;', {sourceType: 'module'});
 
 export default function typeTemplate(type) {
   const replacements = {
@@ -21,10 +17,6 @@ export default function typeTemplate(type) {
   };
 
   const declaration = buildDeclaration(replacements);
-  const fieldBaseTypesFreezeStatement = buildFieldBaseTypesFreezeStatement(replacements);
-  const relayInputObjectBaseTypesFreezeStatement = buildRelayInputObjectBaseTypesFreezeStatement(replacements);
-  const inputFieldBaseTypesFreezeStatement = buildInputFieldBaseTypesFreezeStatement(replacements);
-  const possibleTypesFreezeStatement = buildPossibleTypesFreezeStatement(replacements);
   const moduleExport = buildExport(replacements);
 
   switch (type.kind) {
@@ -32,28 +24,22 @@ export default function typeTemplate(type) {
       if (type.name === 'Mutation') {
         return parse(`
             ${generate(declaration).code}
-            ${generate(fieldBaseTypesFreezeStatement).code}
-            ${generate(relayInputObjectBaseTypesFreezeStatement).code}
             ${generate(moduleExport).code}
         `, {sourceType: 'module'});
       } else {
         return parse(`
             ${generate(declaration).code}
-            ${generate(fieldBaseTypesFreezeStatement).code}
             ${generate(moduleExport).code}
         `, {sourceType: 'module'});
       }
     case 'INTERFACE':
       return parse(`
           ${generate(declaration).code}
-          ${generate(fieldBaseTypesFreezeStatement).code}
-          ${generate(possibleTypesFreezeStatement).code}
           ${generate(moduleExport).code}
       `, {sourceType: 'module'});
     case 'INPUT_OBJECT':
       return parse(`
           ${generate(declaration).code}
-          ${generate(inputFieldBaseTypesFreezeStatement).code}
           ${generate(moduleExport).code}
       `, {sourceType: 'module'});
     default:

--- a/src/writers.js
+++ b/src/writers.js
@@ -1,0 +1,53 @@
+import {rollup} from 'rollup';
+import fs from 'fs';
+import path from 'path';
+import mkdirp from 'mkdirp';
+import tmp from 'tmp';
+import dasherize from 'lodash.kebabcase';
+
+function logFileWrite(filePath) {
+  console.log(`wroteFile: ${filePath}`);
+}
+
+export function writeFiles(outdir, files, quiet = false) {
+  return Promise.all(files.map((file) => {
+    return new Promise((resolve, reject) => {
+      fs.writeFile(path.join(outdir, file.path), file.body, (err) => {
+        if (err) {
+          reject(err);
+
+          return;
+        }
+
+        if (!quiet) {
+          logFileWrite(path.join(outdir, file.path));
+        }
+        resolve();
+      });
+    });
+  }));
+}
+
+export function rollupAndWriteBundle(schemaBundleName, outdir, files) {
+  tmp.setGracefulCleanup();
+  const tmpDir = tmp.dirSync();
+
+  mkdirp.sync(path.join(tmpDir.name, 'types'));
+
+  const entryFilename = `${dasherize(schemaBundleName)}.js`;
+  const entryFilePath = path.join(tmpDir.name, entryFilename);
+  const bundleFilePath = path.join(outdir, entryFilename);
+
+  return writeFiles(tmpDir.name, files, true).then(() => {
+    return rollup({
+      entry: entryFilePath
+    });
+  }).then((bundle) => {
+    return bundle.write({
+      format: 'es',
+      dest: bundleFilePath
+    });
+  }).then(() => {
+    logFileWrite(bundleFilePath);
+  });
+}

--- a/test-fixtures/input-object-type-template-output.js
+++ b/test-fixtures/input-object-type-template-output.js
@@ -7,5 +7,4 @@ const ApiCustomerAccessTokenCreateInput = {
     "password": "String"
   }
 };
-Object.freeze(ApiCustomerAccessTokenCreateInput.inputFieldBaseTypes);
-export default Object.freeze(ApiCustomerAccessTokenCreateInput);
+export default ApiCustomerAccessTokenCreateInput;

--- a/test-fixtures/interface-type-template-output.js
+++ b/test-fixtures/interface-type-template-output.js
@@ -6,6 +6,4 @@ const Node = {
   },
   "possibleTypes": ["ApiCustomerAccessToken", "Collection", "CreditCardPaymentRequest", "Order", "Product", "ProductOption", "ProductVariant", "PurchaseSession", "ShippingRatesRequest", "ShopPolicy"]
 };
-Object.freeze(Node.fieldBaseTypes);
-Object.freeze(Node.possibleTypes);
-export default Object.freeze(Node);
+export default Node;

--- a/test-fixtures/multi-resource-bundle.js
+++ b/test-fixtures/multi-resource-bundle.js
@@ -10,5 +10,16 @@ Types.types["Collection"] = Collection;
 Types.queryType = "Shop";
 Types.mutationType = null;
 Types.subscriptionType = null;
-Object.freeze(Types.types);
-export default Object.freeze(Types);
+
+function recursivelyFreezeObject(structure) {
+  Object.getOwnPropertyNames(structure).forEach(key => {
+    const value = structure[key];
+    if (value && typeof value === 'object') {
+      recursivelyFreezeObject(value);
+    }
+  });
+  Object.freeze(structure);
+  return structure;
+}
+
+export default recursivelyFreezeObject(Types);

--- a/test-fixtures/mutation-object-type-template-output.js
+++ b/test-fixtures/mutation-object-type-template-output.js
@@ -13,6 +13,4 @@ const Mutation = {
     "apiCustomerAccessTokenRenew": "ApiCustomerAccessTokenRenewInput"
   }
 };
-Object.freeze(Mutation.fieldBaseTypes);
-Object.freeze(Mutation.relayInputObjectBaseTypes);
-export default Object.freeze(Mutation);
+export default Mutation;

--- a/test-fixtures/object-type-template-output.js
+++ b/test-fixtures/object-type-template-output.js
@@ -18,5 +18,4 @@ const Product = {
   },
   "implementsNode": true
 };
-Object.freeze(Product.fieldBaseTypes);
-export default Object.freeze(Product);
+export default Product;

--- a/test-fixtures/simplified-schema-bundle-with-whitelist.json
+++ b/test-fixtures/simplified-schema-bundle-with-whitelist.json
@@ -1,11 +1,11 @@
 [
   {
     "name": "QueryRoot",
-    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nexport default Object.freeze(QueryRoot);",
+    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nexport default QueryRoot;",
     "path": "types/query-root.js"
   },
   {
-    "body": "\nimport QueryRoot from \"./types/query-root\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.queryType = \"QueryRoot\";\nSchema.mutationType = \"Mutation\";\nSchema.subscriptionType = null;\nObject.freeze(Schema.types);\nexport default Object.freeze(Schema);",
+    "body": "\nimport QueryRoot from \"./types/query-root\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.queryType = \"QueryRoot\";\nSchema.mutationType = \"Mutation\";\nSchema.subscriptionType = null;\n\nfunction recursivelyFreezeObject(structure) {\n  Object.getOwnPropertyNames(structure).forEach(key => {\n    const value = structure[key];\n    if (value && typeof value === 'object') {\n      recursivelyFreezeObject(value);\n    }\n  });\n  Object.freeze(structure);\n  return structure;\n}\n\nexport default recursivelyFreezeObject(Schema);",
     "path": "schema.js"
   }
 ]

--- a/test-fixtures/simplified-schema-bundle.json
+++ b/test-fixtures/simplified-schema-bundle.json
@@ -1,21 +1,21 @@
 [
   {
     "name": "QueryRoot",
-    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nObject.freeze(QueryRoot.fieldBaseTypes);\nexport default Object.freeze(QueryRoot);",
+    "body": "\nconst QueryRoot = {\n  \"name\": \"QueryRoot\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"collection\": \"Collection\",\n    \"node\": \"Node\",\n    \"product\": \"Product\",\n    \"shop\": \"Shop\"\n  },\n  \"implementsNode\": false\n};\nexport default QueryRoot;",
     "path": "types/query-root.js"
   },
   {
     "name": "Node",
-    "body": "\nconst Node = {\n  \"name\": \"Node\",\n  \"kind\": \"INTERFACE\",\n  \"fieldBaseTypes\": {\n    \"id\": \"ID\"\n  },\n  \"possibleTypes\": [\"Collection\", \"Product\", \"ProductOption\", \"ProductVariant\"]\n};\nObject.freeze(Node.fieldBaseTypes);\nObject.freeze(Node.possibleTypes);\nexport default Object.freeze(Node);",
+    "body": "\nconst Node = {\n  \"name\": \"Node\",\n  \"kind\": \"INTERFACE\",\n  \"fieldBaseTypes\": {\n    \"id\": \"ID\"\n  },\n  \"possibleTypes\": [\"Collection\", \"Product\", \"ProductOption\", \"ProductVariant\"]\n};\nexport default Node;",
     "path": "types/node.js"
   },
   {
     "name": "Mutation",
-    "body": "\nconst Mutation = {\n  \"name\": \"Mutation\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"apiCustomerAccessTokenCreate\": \"ApiCustomerAccessTokenCreatePayload\",\n    \"apiCustomerAccessTokenDelete\": \"ApiCustomerAccessTokenDeletePayload\",\n    \"apiCustomerAccessTokenRenew\": \"ApiCustomerAccessTokenRenewPayload\"\n  },\n  \"implementsNode\": false,\n  \"relayInputObjectBaseTypes\": {\n    \"apiCustomerAccessTokenCreate\": \"ApiCustomerAccessTokenCreateInput\",\n    \"apiCustomerAccessTokenDelete\": \"ApiCustomerAccessTokenDeleteInput\",\n    \"apiCustomerAccessTokenRenew\": \"ApiCustomerAccessTokenRenewInput\"\n  }\n};\nObject.freeze(Mutation.fieldBaseTypes);\nObject.freeze(Mutation.relayInputObjectBaseTypes);\nexport default Object.freeze(Mutation);",
+    "body": "\nconst Mutation = {\n  \"name\": \"Mutation\",\n  \"kind\": \"OBJECT\",\n  \"fieldBaseTypes\": {\n    \"apiCustomerAccessTokenCreate\": \"ApiCustomerAccessTokenCreatePayload\",\n    \"apiCustomerAccessTokenDelete\": \"ApiCustomerAccessTokenDeletePayload\",\n    \"apiCustomerAccessTokenRenew\": \"ApiCustomerAccessTokenRenewPayload\"\n  },\n  \"implementsNode\": false,\n  \"relayInputObjectBaseTypes\": {\n    \"apiCustomerAccessTokenCreate\": \"ApiCustomerAccessTokenCreateInput\",\n    \"apiCustomerAccessTokenDelete\": \"ApiCustomerAccessTokenDeleteInput\",\n    \"apiCustomerAccessTokenRenew\": \"ApiCustomerAccessTokenRenewInput\"\n  }\n};\nexport default Mutation;",
     "path": "types/mutation.js"
   },
   {
-    "body": "\nimport QueryRoot from \"./types/query-root\";\nimport Node from \"./types/node\";\nimport Mutation from \"./types/mutation\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.types[\"Node\"] = Node;\nSchema.types[\"Mutation\"] = Mutation;\nSchema.queryType = \"QueryRoot\";\nSchema.mutationType = \"Mutation\";\nSchema.subscriptionType = null;\nObject.freeze(Schema.types);\nexport default Object.freeze(Schema);",
+    "body": "\nimport QueryRoot from \"./types/query-root\";\nimport Node from \"./types/node\";\nimport Mutation from \"./types/mutation\";\nconst Schema = {\n  types: {}\n};\nSchema.types[\"QueryRoot\"] = QueryRoot;\nSchema.types[\"Node\"] = Node;\nSchema.types[\"Mutation\"] = Mutation;\nSchema.queryType = \"QueryRoot\";\nSchema.mutationType = \"Mutation\";\nSchema.subscriptionType = null;\n\nfunction recursivelyFreezeObject(structure) {\n  Object.getOwnPropertyNames(structure).forEach(key => {\n    const value = structure[key];\n    if (value && typeof value === 'object') {\n      recursivelyFreezeObject(value);\n    }\n  });\n  Object.freeze(structure);\n  return structure;\n}\n\nexport default recursivelyFreezeObject(Schema);",
     "path": "schema.js"
   }
 ]

--- a/test-fixtures/single-resource-bundle.js
+++ b/test-fixtures/single-resource-bundle.js
@@ -6,5 +6,16 @@ Schema.types["SomeType"] = SomeType;
 Schema.queryType = "SomeType";
 Schema.mutationType = null;
 Schema.subscriptionType = null;
-Object.freeze(Schema.types);
-export default Object.freeze(Schema);
+
+function recursivelyFreezeObject(structure) {
+  Object.getOwnPropertyNames(structure).forEach(key => {
+    const value = structure[key];
+    if (value && typeof value === 'object') {
+      recursivelyFreezeObject(value);
+    }
+  });
+  Object.freeze(structure);
+  return structure;
+}
+
+export default recursivelyFreezeObject(Schema);

--- a/test-fixtures/zero-resource-bundle.js
+++ b/test-fixtures/zero-resource-bundle.js
@@ -5,5 +5,16 @@ const Bundle = {
 Bundle.queryType = null;
 Bundle.mutationType = null;
 Bundle.subscriptionType = null;
-Object.freeze(Bundle.types);
-export default Object.freeze(Bundle);
+
+function recursivelyFreezeObject(structure) {
+  Object.getOwnPropertyNames(structure).forEach(key => {
+    const value = structure[key];
+    if (value && typeof value === 'object') {
+      recursivelyFreezeObject(value);
+    }
+  });
+  Object.freeze(structure);
+  return structure;
+}
+
+export default recursivelyFreezeObject(Bundle);

--- a/test/bundling-integration-test.js
+++ b/test/bundling-integration-test.js
@@ -1,0 +1,78 @@
+import assert from 'assert';
+import tmp from 'tmp';
+import path from 'path';
+import {transformFileSync} from 'babel-core';
+import {writeFileSync} from 'fs';
+
+import getFixture from './get-fixture';
+import {rollupAndWriteBundle} from '../src/writers';
+import generateSchemaModules from '../src/index';
+
+function buildCompileAndImportModule() {
+  tmp.setGracefulCleanup();
+
+  const tmpDir = tmp.dirSync().name;
+
+  const introspectionResponse = JSON.parse(getFixture('schema.json'));
+  const modules = generateSchemaModules(introspectionResponse, 'Schema');
+
+  return rollupAndWriteBundle('Schema', tmpDir, modules).then(() => {
+    const bundleFileName = path.join(tmpDir, 'schema.js');
+    const options = {
+      presets: [
+        path.join(process.cwd(), 'node_modules/babel-preset-shopify/node')
+      ]
+    };
+    const body = transformFileSync(bundleFileName, options).code;
+
+    const compiledFilePath = path.join(tmpDir, 'compiled.js');
+
+    writeFileSync(compiledFilePath, body);
+
+    try {
+      const bundle = require(compiledFilePath).default;
+
+      return Promise.resolve(bundle);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  });
+}
+
+suite('bundling-integration-test', () => {
+  test('it creates an importable bundle', () => {
+    // will reject on failure
+    return buildCompileAndImportModule().then((bundle) => {
+      assert.ok(bundle, 'program can be imported');
+    }).catch((error) => {
+      assert.ok(false, `the modules could not be imported:
+        ${error.toString()}`);
+    });
+  });
+
+  test('it deeply freezes the type bundle', () => {
+    let leafCount = 0;
+
+    function assertDeeplyFrozen(structure) {
+      leafCount++;
+
+      assert.ok(Object.isFrozen(structure), `structure not frozen at entry ${structure}`);
+
+      Object.getOwnPropertyNames(structure).forEach((key) => {
+        const value = structure[key];
+
+        if (value && typeof value === 'object') {
+          assertDeeplyFrozen(value);
+        }
+      });
+    }
+
+    return buildCompileAndImportModule().then((bundle) => {
+      assertDeeplyFrozen(bundle);
+      assert.equal(leafCount, 10, 'it traversed all objects in the tree');
+    }, (error) => {
+      assert.ok(false, `the modules could not be imported:
+        ${error.toString()}`);
+    });
+  });
+});


### PR DESCRIPTION
#By programmatically freezing data in the bundle on export, we can save about 25% of the file size on medium sized bundles.

Using the storefront schema, we see the following results:

- __master:__  `49K`
- __programmatically-freeze-types:__ `37K`