### PR TITLE
Add support to CommonJS usage in generated Types file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ modules, run the following command.
 graphql-js-schema --schema-file ./schema.json --outdir schema --schema-bundle-name="Types"
 ```
 
+### Optional support to CommonJS
+
+```bash
+graphql-js-schema --schema-file ./schema.json --outdir schema --schema-bundle-name="Types" --commonjs
+```
+
 This will create a directory called schema, and a root module called `Schema` in
 the file `schema/types.js`. It will also collect all the non-scalar types in
 `schema/types/`, and export them. The top level bundle exists for convenience,

--- a/src/bundle-template.js
+++ b/src/bundle-template.js
@@ -4,17 +4,29 @@ import template from 'babel-template';
 import generate from 'babel-generator';
 import {parse} from 'babylon';
 
-function buildImport(replacements) {
+function buildImport(replacements, commonjs) {
   const modulePath = replacements.TYPE_MODULE_PATH.value;
+
+  if (commonjs) {
+    return template(`const TYPE_NAME_IDENTIFIER = require("./${modulePath}");`, {sourceType: 'module'})(replacements);
+  }
 
   return template(`import TYPE_NAME_IDENTIFIER from "./${modulePath}";`, {sourceType: 'module'})(replacements);
 }
+
+function buildExport(replacements, commonjs) {
+  if (commonjs) {
+    return template('module.exports = recursivelyFreezeObject(BUNDLE_MODULE_NAME);', {sourceType: 'module'})(replacements);
+  }
+
+  return template('export default recursivelyFreezeObject(BUNDLE_MODULE_NAME);', {sourceType: 'module'})(replacements);
+}
+
 const buildDeclaration = template('const BUNDLE_MODULE_NAME = {types: {}};');
 const buildModuleAssignment = template('BUNDLE_MODULE_NAME.types[TYPE_NAME] = TYPE_NAME_IDENTIFIER;');
 const buildRootLevelAssignment = template('BUNDLE_MODULE_NAME.PROPERTY_NAME = PROPERTY_VALUE;');
-const buildExport = template('export default recursivelyFreezeObject(BUNDLE_MODULE_NAME);', {sourceType: 'module'});
 
-export default function bundleTemplate({queryTypeName, mutationTypeName, subscriptionTypeName}, types, bundleModuleName) {
+export default function bundleTemplate({queryTypeName, mutationTypeName, subscriptionTypeName}, types, bundleModuleName, commonjs) {
   const BUNDLE_MODULE_NAME = t.identifier(bundleModuleName);
   const QUERY_TYPE_NAME = queryTypeName ? t.stringLiteral(queryTypeName) : t.nullLiteral();
   const MUTATION_TYPE_NAME = mutationTypeName ? t.stringLiteral(mutationTypeName) : t.nullLiteral();
@@ -29,13 +41,13 @@ export default function bundleTemplate({queryTypeName, mutationTypeName, subscri
     };
   });
 
-  const imports = typeConfigs.map((typeConfig) => buildImport(typeConfig));
+  const imports = typeConfigs.map((typeConfig) => buildImport(typeConfig, commonjs));
   const declaration = buildDeclaration({BUNDLE_MODULE_NAME});
   const assignments = typeConfigs.map((typeConfig) => buildModuleAssignment(typeConfig));
   const queryTypeAssignment = buildRootLevelAssignment({BUNDLE_MODULE_NAME, PROPERTY_NAME: t.identifier('queryType'), PROPERTY_VALUE: QUERY_TYPE_NAME});
   const mutationTypeAssignment = buildRootLevelAssignment({BUNDLE_MODULE_NAME, PROPERTY_NAME: t.identifier('mutationType'), PROPERTY_VALUE: MUTATION_TYPE_NAME});
   const subscriptionTypeAssignment = buildRootLevelAssignment({BUNDLE_MODULE_NAME, PROPERTY_NAME: t.identifier('subscriptionType'), PROPERTY_VALUE: SUBSCRIPTION_TYPE_NAME});
-  const moduleExport = buildExport({BUNDLE_MODULE_NAME});
+  const moduleExport = buildExport({BUNDLE_MODULE_NAME}, commonjs);
 
   return parse(`
     ${imports.map((ast) => generate(ast).code).join('\n')}

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,7 +33,7 @@ function runCli() {
     });
 
   } else {
-    const files = generateSchemaModules(introspectionResponse, args.schemaBundleName, whitelistConfig);
+    const files = generateSchemaModules(introspectionResponse, args.schemaBundleName, whitelistConfig, args.commonjs);
 
     mkdirp.sync(path.join(args.outdir, 'types'));
 

--- a/src/parse-args.js
+++ b/src/parse-args.js
@@ -6,7 +6,10 @@ function shouldShowHelp(args) {
 
 export default function parseArgs(rawArgs) {
   const args = minimist(rawArgs, {
-    boolean: 'bundle-only',
+    boolean: [
+      'bundle-only',
+      'commonjs'
+    ],
     string: [
       'schema-file',
       'outdir',
@@ -15,7 +18,8 @@ export default function parseArgs(rawArgs) {
     ],
     default: {
       'schema-bundle-name': 'Schema',
-      'bundle-only': false
+      'bundle-only': false,
+      commonjs: false
     }
   });
 
@@ -28,6 +32,7 @@ export default function parseArgs(rawArgs) {
     outdir: args.outdir,
     schemaBundleName: args['schema-bundle-name'],
     bundleOnly: args['bundle-only'],
-    whitelistConfig: args['whitelist-config']
+    whitelistConfig: args['whitelist-config'],
+    commonjs: args.commonjs
   };
 }

--- a/src/type-template.js
+++ b/src/type-template.js
@@ -8,16 +8,23 @@ function buildDeclaration(replacements) {
 
   return template(`const TYPE_NAME_IDENTIFIER = ${JSON.stringify(object, null, 2)};`)(replacements);
 }
-const buildExport = template('export default TYPE_NAME_IDENTIFIER;', {sourceType: 'module'});
 
-export default function typeTemplate(type) {
+function buildExport(replacements, commonjs) {
+  if (commonjs) {
+    return template('module.exports = TYPE_NAME_IDENTIFIER;', {sourceType: 'module'})(replacements);
+  }
+
+  return template('export default TYPE_NAME_IDENTIFIER;', {sourceType: 'module'})(replacements);
+}
+
+export default function typeTemplate(type, commonjs) {
   const replacements = {
     TYPE_NAME_IDENTIFIER: t.identifier(type.name),
     TYPE_HASH: type
   };
 
   const declaration = buildDeclaration(replacements);
-  const moduleExport = buildExport(replacements);
+  const moduleExport = buildExport(replacements, commonjs);
 
   switch (type.kind) {
     case 'OBJECT':

--- a/test/parse-args-test.js
+++ b/test/parse-args-test.js
@@ -14,6 +14,7 @@ suite('parse-args-test', () => {
   test('it can parse passed args', () => {
     const opts = parseArgs([
       '--bundle-only',
+      '--commonjs',
       '--schema-bundle-name',
       'Types'
     ].concat(...requiredArgs));
@@ -22,6 +23,7 @@ suite('parse-args-test', () => {
     assert.equal(opts.outdir, 'whatever');
     assert.equal(opts.schemaBundleName, 'Types');
     assert.equal(opts.bundleOnly, true);
+    assert.equal(opts.commonjs, true);
   });
 
   test('it shows help when required args are missing', () => {


### PR DESCRIPTION
@minasmart review please.
This PR adds the functionality of creating a `types` file with CommonJS modules.

### Feature behavior:
If the `--commonjs` arg is passed in CLI, it adds the argument `commonjs` to be `true` and be passed from parent to children until templates builder to check if the generated file must be built using CommonJS modules.

If `--commonjs` arg is not passed, then `graphql-js-schema` must behave generating `types` files using ES Modules, as it is and `commonjs` arg is `false` in its default value, as specified in `src/parse-args.js`.

_If is there anything that can be improved in this PR, I would love to hear/read. Cheers._ :)